### PR TITLE
Change small part of code to a more ergonomic method

### DIFF
--- a/src/basic_formulas.rs
+++ b/src/basic_formulas.rs
@@ -26,7 +26,7 @@ impl EmpiricalFormula {
             return Err(());
         }
         while !string.is_empty() {
-            if string[0] < b'A' || string[0] > b'Z' {
+            if !string[0].is_ascii_uppercase() {
                 return Err(());
             }
             let (e, s) = parse_element(string);
@@ -42,7 +42,7 @@ impl EmpiricalFormula {
                 elements.push((e, count));
                 break;
             }
-            if string[0] >= b'0' && string[0] <= b'9' {
+            if string[0].is_ascii_digit() {
                 let (c, s) = parse_number(string);
                 count = c;
                 elements.push((e, count));
@@ -188,7 +188,7 @@ fn parse_group(mut string: &[u8]) -> Result<(MolecularFormula, &[u8]), ()> {
             ElementOrGroup::Group(g)
         }
         else {
-            if string[0] < b'A' || string[0] > b'Z' {
+            if !string[0].is_ascii_uppercase() {
                 return Err(());
             }
             let (e, s) = parse_element(string);
@@ -205,7 +205,7 @@ fn parse_group(mut string: &[u8]) -> Result<(MolecularFormula, &[u8]), ()> {
         if string.is_empty() {
             return Err(());
         }
-        if string[0] >= b'0' && string[0] <= b'9' {
+        if string[0].is_ascii_digit() {
             let (c, s) = parse_number(string);
             count = c;
             result.push((e, count));
@@ -242,7 +242,7 @@ impl MolecularFormula {
                 ElementOrGroup::Group(g)
             }
             else {
-                if string[0] < b'A' || string[0] > b'Z' {
+                if !string[0].is_ascii_uppercase() {
                     return Err(());
                 }
                 let (e, s) = parse_element(string);
@@ -260,7 +260,7 @@ impl MolecularFormula {
                 result.push((e, count));
                 break;
             }
-            if string[0] >= b'0' && string[0] <= b'9' {
+            if string[0].is_ascii_digit() {
                 let (c, s) = parse_number(string);
                 count = c;
                 result.push((e, count));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use basic_formulas::*;
 
 fn parse_element(string: &[u8]) -> (Option<Element>, &[u8]) {
     let mut end = 1;
-    if string.len() >= 2 && string[1] >= b'a' && string[1] <= b'z' {
+    if string.len() >= 2 && string[1].is_ascii_lowercase() {
         end += 1;
     }
     (Element::from_symbol(unsafe { mem::transmute(&string[..end]) }), &string[end..])
@@ -22,7 +22,7 @@ fn parse_element(string: &[u8]) -> (Option<Element>, &[u8]) {
 fn parse_number(string: &[u8]) -> (usize, &[u8]) {
     let mut digits = Vec::new();
     let mut end = 0;
-    while string.len() > end && (string[end] >= b'0' && string[end] <= b'9') {
+    while string.len() > end && string[end].is_ascii_digit() {
         digits.push(string[end] - b'0');
         end += 1;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ fn parse_element(string: &[u8]) -> (Option<Element>, &[u8]) {
     if string.len() >= 2 && string[1].is_ascii_lowercase() {
         end += 1;
     }
-    (Element::from_symbol(unsafe { mem::transmute(&string[..end]) }), &string[end..])
+    (Element::from_symbol(unsafe { std::str::from_utf8_unchecked(&string[..end]) }), &string[end..])
 }
 
 fn parse_number(string: &[u8]) -> (usize, &[u8]) {


### PR DESCRIPTION
This is my first open source contribution so apologize in advance if I've done anything inappropriate.

This PR change small part of code to be more ergonomic, mainly
1. use `u8` method for ascii comparison (eg. `is_ascii_uppercase`, `is_ascii_digit`)
2. use `std::str::from_utf8_unchecked` instead of a more dangerous `mem::transmute`

Because rust's zero cost abstractions, the functionality and performance should be completely unaffected while making code more readable.